### PR TITLE
Implements Count-Min-Sketch RedisBloom Commands

### DIFF
--- a/src/main/java/io/rebloom/client/Client.java
+++ b/src/main/java/io/rebloom/client/Client.java
@@ -374,7 +374,7 @@ public class Client implements CMS, Closeable {
  }
 
  @Override
- public Long cmsIncrBy(String key, String item, long increment) {
+ public long cmsIncrBy(String key, String item, long increment) {
    try (Jedis conn = _conn()) {
      return sendCommand(conn, CMSCommand.INCRBY, //
          SafeEncoder.encode(key), //

--- a/src/main/java/io/rebloom/client/Client.java
+++ b/src/main/java/io/rebloom/client/Client.java
@@ -451,16 +451,13 @@ public class Client implements CMS, Closeable {
  }
 
  @Override
- public Map<String, Object> cmsInfo(String key) {
+ public Map<String, Long> cmsInfo(String key) {
    try (Jedis conn = _conn()) {
      List<Object> values = sendCommand(conn, CMSCommand.INFO, SafeEncoder.encode(key)).getObjectMultiBulkReply();
 
-     Map<String, Object> infoMap = new HashMap<>(values.size() / 2);
+     Map<String, Long> infoMap = new HashMap<>(values.size() / 2);
      for (int i = 0; i < values.size(); i += 2) {
-       Object val = values.get(i + 1);
-       if (val instanceof byte[]) {
-         val = SafeEncoder.encode((byte[]) val);
-       }
+       Long val = (Long) values.get(i + 1);
        infoMap.put(SafeEncoder.encode((byte[]) values.get(i)), val);
      }
      return infoMap;

--- a/src/main/java/io/rebloom/client/cms/CMS.java
+++ b/src/main/java/io/rebloom/client/cms/CMS.java
@@ -1,0 +1,96 @@
+package io.rebloom.client.cms;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface for RedisBloom Count-Min Sketch Commands
+ * 
+ * @see <a href=
+ *      "https://oss.redislabs.com/redisbloom/CountMinSketch_Commands/">RedisBloom
+ *      Count-Min Sketch Documentation</a>
+ */
+public interface CMS {
+  /**
+   * CMS.INITBYDIM Initializes a Count-Min Sketch to dimensions specified by user.
+   * 
+   * @param key   The name of the sketch
+   * @param width Number of counter in each array. Reduces the error size
+   * @param depth Number of counter-arrays. Reduces the probability for an error
+   *              of a certain size (percentage of total count
+   */
+  void cmsInitByDim(String key, long width, long depth);
+
+  /**
+   * CMS.INITBYPROB Initializes a Count-Min Sketch to accommodate requested
+   * capacity.
+   * 
+   * @param key         The name of the sketch.
+   * @param error       Estimate size of error. The error is a percent of total
+   *                    counted items. This effects the width of the sketch.
+   * @param probability The desired probability for inflated count. This should be
+   *                    a decimal value between 0 and 1. This effects the depth of
+   *                    the sketch. For example, for a desired false positive rate
+   *                    of 0.1% (1 in 1000), error_rate should be set to 0.001.
+   *                    The closer this number is to zero, the greater the memory
+   *                    consumption per item and the more CPU usage per operation.
+   */
+  void cmsInitByProb(String key, double error, double probability);
+
+  /**
+   * CMS.INCRBY Increases the count of item by increment
+   * 
+   * @param key       The name of the sketch
+   * @param item      The item which counter to be increased
+   * @param increment Counter to be increased by this integer
+   * @return Count for the item after increment
+   */
+  Long cmsIncrBy(String key, String item, long increment);
+
+  /**
+   * CMS.INCRBY Increases the count of one or more item.
+   * 
+   * @param key            The name of the sketch
+   * @param itemIncrements a Map of the items to be increased and their integer
+   *                       increment
+   * @return Count of each item after increment
+   */
+  List<Long> cmsIncrBy(String key, Map<String, Long> itemIncrements);
+
+  /**
+   * CMS.QUERY Returns count for item. Multiple items can be queried with one
+   * call.
+   * 
+   * @param key   The name of the sketch
+   * @param items The items for which to retrieve the counts
+   * @return Count for one or more items
+   */
+  List<Long> cmsQuery(String key, String... items);
+
+  /**
+   * CMS.MERGE Merges several sketches into one sketch. All sketches must have
+   * identical width and depth.
+   * 
+   * @param destKey The name of destination sketch. Must be initialized.
+   * @param keys    The sketches to be merged
+   */
+  void cmsMerge(String destKey, String... keys);
+
+  /**
+   * CMS.MERGE Merges several sketches into one sketch. All sketches must have
+   * identical width and depth. Weights can be used to multiply certain sketches.
+   * Default weight is 1.
+   * 
+   * @param destKey        The name of destination sketch. Must be initialized.
+   * @param keysAndWeights A map of keys and weights used to multiply the sketch.
+   */
+  void cmsMerge(String destKey, Map<String, Long> keysAndWeights);
+
+  /**
+   * CMS.INFO Returns width, depth and total count of the sketch.
+   * 
+   * @param key The name of the sketch
+   * @return A Map with width, depth and total count.
+   */
+  Map<String, Object> cmsInfo(String key);
+}

--- a/src/main/java/io/rebloom/client/cms/CMS.java
+++ b/src/main/java/io/rebloom/client/cms/CMS.java
@@ -92,5 +92,5 @@ public interface CMS {
    * @param key The name of the sketch
    * @return A Map with width, depth and total count.
    */
-  Map<String, Object> cmsInfo(String key);
+  Map<String, Long> cmsInfo(String key);
 }

--- a/src/main/java/io/rebloom/client/cms/CMS.java
+++ b/src/main/java/io/rebloom/client/cms/CMS.java
@@ -45,7 +45,7 @@ public interface CMS {
    * @param increment Counter to be increased by this integer
    * @return Count for the item after increment
    */
-  Long cmsIncrBy(String key, String item, long increment);
+  long cmsIncrBy(String key, String item, long increment);
 
   /**
    * CMS.INCRBY Increases the count of one or more item.

--- a/src/main/java/io/rebloom/client/cms/CMSCommand.java
+++ b/src/main/java/io/rebloom/client/cms/CMSCommand.java
@@ -1,0 +1,23 @@
+package io.rebloom.client.cms;
+
+import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.util.SafeEncoder;
+
+public enum CMSCommand implements ProtocolCommand {
+  INITBYDIM("CMS.INITBYDIM"), //
+  INITBYPROB("CMS.INITBYPROB"), //
+  INCRBY("CMS.INCRBY"), //
+  QUERY("CMS.QUERY"), //
+  MERGE("CMS.MERGE"), //
+  INFO("CMS.INFO");
+
+  private final byte[] raw;
+
+  CMSCommand(String alt) {
+    raw = SafeEncoder.encode(alt);
+  }
+
+  public byte[] getRaw() {
+    return raw;
+  }
+}

--- a/src/test/java/io/rebloom/client/CMSTests.java
+++ b/src/test/java/io/rebloom/client/CMSTests.java
@@ -1,0 +1,160 @@
+package io.rebloom.client;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import redis.clients.jedis.exceptions.JedisException;
+
+/**
+ * Tests for the Count-Min-Sketch Implementation
+ *
+ */
+public class CMSTests {
+  static final int port;
+  static {
+    String tmpPort = System.getenv("REBLOOM_TEST_PORT");
+    if (tmpPort != null && !tmpPort.isEmpty()) {
+      port = Integer.parseInt(tmpPort);
+    } else {
+      port = 6379;
+    }
+  }
+
+  Client cl = null;
+
+  @Before
+  public void clearDb() {
+    cl = new Client("localhost", port);
+    cl._conn().flushDB();
+  }
+
+  @Test
+  public void testInitByDim() {
+    cl.cmsInitByDim("cms1", 16L, 4L);
+    Map<String, Object> info = cl.cmsInfo("cms1");
+    assertEquals(16L, info.get("width"));
+    assertEquals(4L, info.get("depth"));
+    assertEquals(0L, info.get("count"));
+  }
+
+  @Test
+  public void testInitByProb() {
+    cl.cmsInitByProb("cms2", 0.01, 0.01);
+    Map<String, Object> info = cl.cmsInfo("cms2");
+    assertEquals(200L, info.get("width"));
+    assertEquals(7L, info.get("depth"));
+    assertEquals(0L, info.get("count"));
+  }
+
+  @Test
+  public void testKeyAlreadyExists() {
+    cl.cmsInitByDim("dup", 16L, 4L);
+    JedisException thrown = assertThrows(JedisException.class, () -> {
+      cl.cmsInitByDim("dup", 8L, 6L);
+    });
+    assertEquals("CMS: key already exists", thrown.getMessage());
+  }
+
+  @Test
+  public void testIncrBy() {
+    cl.cmsInitByDim("cms3", 1000L, 5L);
+    long resp = cl.cmsIncrBy("cms3", "foo", 5L);
+    assertEquals(5L, resp);
+
+    Map<String, Object> info = cl.cmsInfo("cms3");
+    assertEquals(1000L, info.get("width"));
+    assertEquals(5L, info.get("depth"));
+    assertEquals(5L, info.get("count"));
+  }
+
+  @Test
+  public void testIncrByMultipleArgs() {
+    cl.cmsInitByDim("cms4", 1000L, 5L);
+    cl.cmsIncrBy("cms4", "foo", 5L);
+
+    Map<String, Long> itemIncrements = new HashMap<String, Long>();
+    itemIncrements.put("foo", 5L);
+    itemIncrements.put("bar", 15L);
+
+    List<Long> resp = cl.cmsIncrBy("cms4", itemIncrements);
+    assertArrayEquals(new Long[] { 15L, 10L }, resp.toArray(new Long[0]));
+
+    Map<String, Object> info = cl.cmsInfo("cms4");
+    assertEquals(1000L, info.get("width"));
+    assertEquals(5L, info.get("depth"));
+    assertEquals(25L, info.get("count"));
+  }
+
+  @Test
+  public void testQuery() {
+    cl.cmsInitByDim("cms5", 1000L, 5L);
+
+    Map<String, Long> itemIncrements = new HashMap<String, Long>();
+    itemIncrements.put("foo", 10L);
+    itemIncrements.put("bar", 15L);
+
+    cl.cmsIncrBy("cms5", itemIncrements);
+
+    List<Long> resp = cl.cmsQuery("cms5", "foo", "bar");
+    assertArrayEquals(new Long[] { 10L, 15L }, resp.toArray(new Long[0]));
+  }
+
+  @Test
+  public void testMerge() {
+    cl.cmsInitByDim("A", 1000L, 5L);
+    cl.cmsInitByDim("B", 1000L, 5L);
+    cl.cmsInitByDim("C", 1000L, 5L);
+
+    Map<String, Long> aValues = new HashMap<String, Long>();
+    aValues.put("foo", 5L);
+    aValues.put("bar", 3L);
+    aValues.put("baz", 9L);
+
+    cl.cmsIncrBy("A", aValues);
+
+    Map<String, Long> bValues = new HashMap<String, Long>();
+    bValues.put("foo", 2L);
+    bValues.put("bar", 3L);
+    bValues.put("baz", 1L);
+
+    cl.cmsIncrBy("B", bValues);
+
+    List<Long> q1 = cl.cmsQuery("A", "foo", "bar", "baz");
+    assertArrayEquals(new Long[] { 5L, 3L, 9L }, q1.toArray(new Long[0]));
+
+    List<Long> q2 = cl.cmsQuery("B", "foo", "bar", "baz");
+    assertArrayEquals(new Long[] { 2L, 3L, 1L }, q2.toArray(new Long[0]));
+
+    cl.cmsMerge("C", "A", "B");
+
+    List<Long> q3 = cl.cmsQuery("C", "foo", "bar", "baz");
+    assertArrayEquals(new Long[] { 7L, 6L, 10L }, q3.toArray(new Long[0]));
+
+    Map<String, Long> keysAndWeights = new HashMap<String, Long>();
+    keysAndWeights.put("A", 1L);
+    keysAndWeights.put("B", 2L);
+
+    cl.cmsMerge("C", keysAndWeights);
+
+    List<Long> q4 = cl.cmsQuery("C", "foo", "bar", "baz");
+    assertArrayEquals(new Long[] { 9L, 9L, 11L }, q4.toArray(new Long[0]));
+
+    keysAndWeights.clear();
+    keysAndWeights.put("A", 2L);
+    keysAndWeights.put("B", 3L);
+
+    cl.cmsMerge("C", keysAndWeights);
+
+    List<Long> q5 = cl.cmsQuery("C", "foo", "bar", "baz");
+    assertArrayEquals(new Long[] { 16L, 15L, 21L }, q5.toArray(new Long[0]));
+  }
+
+}

--- a/src/test/java/io/rebloom/client/CMSTests.java
+++ b/src/test/java/io/rebloom/client/CMSTests.java
@@ -39,19 +39,19 @@ public class CMSTests {
   @Test
   public void testInitByDim() {
     cl.cmsInitByDim("cms1", 16L, 4L);
-    Map<String, Object> info = cl.cmsInfo("cms1");
-    assertEquals(16L, info.get("width"));
-    assertEquals(4L, info.get("depth"));
-    assertEquals(0L, info.get("count"));
+    Map<String, Long> info = cl.cmsInfo("cms1");
+    assertEquals(16L, info.get("width").longValue());
+    assertEquals(4L, info.get("depth").longValue());
+    assertEquals(0L, info.get("count").longValue());
   }
 
   @Test
   public void testInitByProb() {
     cl.cmsInitByProb("cms2", 0.01, 0.01);
-    Map<String, Object> info = cl.cmsInfo("cms2");
-    assertEquals(200L, info.get("width"));
-    assertEquals(7L, info.get("depth"));
-    assertEquals(0L, info.get("count"));
+    Map<String, Long> info = cl.cmsInfo("cms2");
+    assertEquals(200L, info.get("width").longValue());
+    assertEquals(7L, info.get("depth").longValue());
+    assertEquals(0L, info.get("count").longValue());
   }
 
   @Test
@@ -69,10 +69,10 @@ public class CMSTests {
     long resp = cl.cmsIncrBy("cms3", "foo", 5L);
     assertEquals(5L, resp);
 
-    Map<String, Object> info = cl.cmsInfo("cms3");
-    assertEquals(1000L, info.get("width"));
-    assertEquals(5L, info.get("depth"));
-    assertEquals(5L, info.get("count"));
+    Map<String, Long> info = cl.cmsInfo("cms3");
+    assertEquals(1000L, info.get("width").longValue());
+    assertEquals(5L, info.get("depth").longValue());
+    assertEquals(5L, info.get("count").longValue());
   }
 
   @Test
@@ -87,10 +87,10 @@ public class CMSTests {
     List<Long> resp = cl.cmsIncrBy("cms4", itemIncrements);
     assertArrayEquals(new Long[] { 15L, 10L }, resp.toArray(new Long[0]));
 
-    Map<String, Object> info = cl.cmsInfo("cms4");
-    assertEquals(1000L, info.get("width"));
-    assertEquals(5L, info.get("depth"));
-    assertEquals(25L, info.get("count"));
+    Map<String, Long> info = cl.cmsInfo("cms4");
+    assertEquals(1000L, info.get("width").longValue());
+    assertEquals(5L, info.get("depth").longValue());
+    assertEquals(25L, info.get("count").longValue());
   }
 
   @Test


### PR DESCRIPTION
- Adds `CMS.java` interface in the `io.rebloom.client.cms` package that implements Count-Min-Sketch commands
- Adds an implementation of the `CMS` interface commands methods to `Client.java`
- Adds tests matching those in https://github.com/RedisBloom/redisbloom-py