### PR TITLE
Implements Cuckoo Filter RedisBloom Commands

### DIFF
--- a/src/main/java/io/rebloom/client/cf/Cuckoo.java
+++ b/src/main/java/io/rebloom/client/cf/Cuckoo.java
@@ -1,0 +1,242 @@
+package io.rebloom.client.cf;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Interface for RedisBloom Cuckoo Filter Commands
+ * 
+ * @see <a href=
+ *      "https://oss.redislabs.com/redisbloom/Cuckoo_Commands/">RedisBloom
+ *      Cuckoo Filter Documentation</a>
+ */
+public interface Cuckoo {
+  /**
+   * CF.RESERVE Creates a Cuckoo Filter under key with a single sub-filter for the
+   * initial capacity
+   * 
+   * @param key      The key under which the filter is found
+   * @param capacity Estimated capacity for the filter
+   */
+  void cfCreate(String key, long capacity);
+
+  /**
+   * CF.RESERVE Creates a Cuckoo Filter under key with a single sub-filter for the
+   * initial capacity and Number of items in each bucket
+   * 
+   * @param key        The key under which the filter is found
+   * @param capacity   Estimated capacity for the filter
+   * @param bucketSize Number of items in each bucket
+   */
+  void cfCreate(String key, long capacity, long bucketSize);
+
+  /**
+   * CF.RESERVE Creates a Cuckoo Filter under key with a single sub-filter for the
+   * initial capacity, Number of items in each bucket and a Max Number of attempts
+   * to swap items between buckets
+   * 
+   * @param key           The key under which the filter is found
+   * @param capacity      Estimated capacity for the filter
+   * @param bucketSize    Number of items in each bucket
+   * @param maxIterations Number of attempts to swap items between buckets before
+   *                      creating an additional filter
+   */
+  void cfCreate(String key, long capacity, long bucketSize, long maxIterations);
+
+  /**
+   * CF.RESERVE Creates a Cuckoo Filter under key with a single sub-filter for the
+   * initial capacity, Number of items in each bucket, Max Number of attempts to
+   * swap items between buckets ad expansion multiplier
+   * 
+   * @param key           The key under which the filter is found
+   * @param capacity      Estimated capacity for the filter
+   * @param bucketSize    Number of items in each bucket
+   * @param maxIterations Number of attempts to swap items between buckets before
+   *                      creating an additional filter
+   * @param expansion     When a new filter is created, its size is the size of
+   *                      the current filter multiplied by expansion
+   */
+  void cfCreate(String key, long capacity, long bucketSize, long maxIterations, long expansion);
+
+  /**
+   * CF.ADD Adds an item to the cuckoo filter, creating the filter if it does not
+   * exist
+   * 
+   * @param key  The name of the filter
+   * @param item The item to add
+   * @return true on success, false otherwise
+   */
+  boolean cfAdd(String key, String item);
+
+  /**
+   * CF.ADDNX Adds an item to the cuckoo filter, only if it does not exist yet
+   * 
+   * @param key  The name of the filter
+   * @param item The item to add
+   * @return true if the item was added to the filter, false if the item already
+   *         exists.
+   */
+  boolean cfAddNx(String key, String item);
+
+  /**
+   * CF.INSERT Adds one or more items to a cuckoo filter, creating it if it does
+   * not exist yet.
+   * 
+   * @param key   The name of the filter
+   * @param items One or more items to add
+   * @return true if the item was successfully inserted, false if an error
+   *         occurred
+   */
+  List<Boolean> cfInsert(String key, String... items);
+
+  /**
+   * CF.INSERT Adds one or more items to a cuckoo filter, allowing the filter to
+   * be created with a custom capacity if it does not exist yet.
+   * 
+   * @param key      The name of the filter
+   * @param capacity Specifies the desired capacity of the new filter, if this
+   *                 filter does not exist yet. If the filter already exists, then
+   *                 this parameter is ignored.
+   * @param items    One or more items to add
+   * @return true if the item was successfully inserted, false if an error
+   *         occurred
+   */
+  List<Boolean> cfInsert(String key, long capacity, String... items);
+
+  /**
+   * CF.INSERT Adds one or more items to a cuckoo filter. If the specified filer
+   * does not exists, false is returned to signify an error.
+   * 
+   * @param key   The name of the filter
+   * @param items One or more items to add
+   * @return true if the item was successfully inserted, false if an error
+   *         occurred
+   */
+  List<Boolean> cfInsertNoCreate(String key, String... items);
+
+  /**
+   * CF.INSERTNX Adds one or more items to a cuckoo filter, only if it does not
+   * exist yet
+   * 
+   * @param key   The name of the filter
+   * @param items One or more items to add
+   * @return true if the item was added to the filter, false if the item already
+   *         exists.
+   */
+  List<Boolean> cfInsertNx(String key, String... items);
+
+  /**
+   * CF.INSERTNX Adds one or more items to a cuckoo filter, only if it does not
+   * exist yet
+   * 
+   * @param key      The name of the filter
+   * @param capacity Specifies the desired capacity of the new filter, if this
+   *                 filter does not exist yet. If the filter already exists, then
+   *                 this parameter is ignored.
+   * @param items    One or more items to add
+   * @return true if the item was added to the filter, false if the item already
+   *         exists.
+   */
+  List<Boolean> cfInsertNx(String key, long capacity, String... items);
+
+  /**
+   * CF.INSERTNX Adds one or more items to a cuckoo filter, only if it does not
+   * exist yet
+   * 
+   * @param key   The name of the filter
+   * @param items One or more items to add
+   * @return true if the item was added to the filter, false if the item already
+   *         exists.
+   */
+  List<Boolean> cfInsertNxNoCreate(String key, String... items);
+
+  /**
+   * CF.EXISTS Check if an item exists in a Cuckoo Filter
+   * 
+   * @param key  The name of the filter
+   * @param item The item to check for
+   * @return false if the item certainly does not exist, true if the item may
+   *         exist.
+   */
+  boolean cfExists(String key, String item);
+
+  /**
+   * CF.DEL Deletes an item once from the filter. If the item exists only once, it
+   * will be removed from the filter. If the item was added multiple times, it
+   * will still be present.
+   * 
+   * @param key  The name of the filter
+   * @param item The item to delete from the filter
+   * @return true if the item has been deleted, false if the item was not found.
+   */
+  boolean cfDel(String key, String item);
+
+  /**
+   * CF.COUNT Returns the number of times an item may be in the filter.
+   * 
+   * @param key  The name of the filter
+   * @param item The item to count
+   * @return The number of times the item exists in the filter
+   */
+  long cfCount(String key, String item);
+
+  /**
+   * CF.SCANDUMP Begins an incremental save of the cuckoo filter. This is useful
+   * for large cuckoo filters which cannot fit into the normal SAVE and RESTORE
+   * model.
+   * 
+   * The Iterator is passed as input to the next invocation of SCANDUMP . If
+   * Iterator is 0, the iteration has completed.
+   * 
+   * @param key      Name of the filter
+   * @param iterator This is either 0, or the iterator from a previous invocation
+   *                 of this command
+   * @return an IteratorDataPair containing the Iterator and Data.
+   */
+  IteratorDataPair cfScanDump(String key, long iterator);
+
+  /**
+   * CF.SCANDUMP Begins an incremental save of the cuckoo filter. This is useful
+   * for large cuckoo filters which cannot fit into the normal SAVE and RESTORE
+   * model.
+   * 
+   * Returns an iterator over the IteratorDataPairs in proper sequence.
+   * 
+   * @param key Name of the filter
+   * @return Returns an iterator over the IteratorDataPairs containing the chunks
+   *         of byte[] representing the filter
+   */
+  Iterator<IteratorDataPair> cfScanDumpIterator(String key);
+
+  /**
+   * CF.SCANDUMP Begins an incremental save of the cuckoo filter. This is useful
+   * for large cuckoo filters which cannot fit into the normal SAVE and RESTORE
+   * model.
+   * 
+   * Returns a sequential Stream with the IteratorDataPairs as its source.
+   * 
+   * @return Returns a sequential Stream of IteratorDataPairs
+   */
+  Stream<IteratorDataPair> cfScanDumpStream(String key);
+
+  /**
+   * CF.LOADCHUNK Restores a filter previously saved using SCANDUMP . See the
+   * SCANDUMP command for example usage.
+   * 
+   * @param key Name of the filter to restore
+   * @param idp an IteratorDataPair containing the Iterator and Data.
+   */
+  void cfLoadChunk(String key, IteratorDataPair idp);
+
+  /**
+   * CF.INFO Return information about filter
+   * 
+   * @param key Name of the filter to restore
+   * @return A Map containing Size, Number of buckets, Number of filter, Number of
+   *         items inserted, Number of items deleted, Bucket size, Expansion rate,
+   *         Max iteration
+   */
+  Map<String, Long> cfInfo(String key);
+}

--- a/src/main/java/io/rebloom/client/cf/CuckooCommand.java
+++ b/src/main/java/io/rebloom/client/cf/CuckooCommand.java
@@ -1,0 +1,28 @@
+package io.rebloom.client.cf;
+
+import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.util.SafeEncoder;
+
+public enum CuckooCommand implements ProtocolCommand {
+  RESERVE("CF.RESERVE"), //
+  ADD("CF.ADD"), //
+  ADDNX("CF.ADDNX"), //
+  INSERT("CF.INSERT"), //
+  INSERTNX("CF.INSERTNX"), //
+  EXIST("CF.EXISTS"), //
+  DEL("CF.DEL"), //
+  COUNT("CF.COUNT"), //
+  SCANDUMP("CF.SCANDUMP"), //
+  LOADCHUNK("CF.LOADCHUNK"), //
+  INFO("CF.INFO");
+
+  private final byte[] raw;
+
+  CuckooCommand(String alt) {
+    raw = SafeEncoder.encode(alt);
+  }
+
+  public byte[] getRaw() {
+    return raw;
+  }
+}

--- a/src/main/java/io/rebloom/client/cf/IteratorDataPair.java
+++ b/src/main/java/io/rebloom/client/cf/IteratorDataPair.java
@@ -1,0 +1,19 @@
+package io.rebloom.client.cf;
+
+public class IteratorDataPair {
+  private long iteratorValue;
+  private byte[] data;
+
+  public IteratorDataPair(Long iteratorValue, byte[] data) {
+    this.iteratorValue = iteratorValue;
+    this.data = data;
+  }
+
+  public long getIteratorValue() {
+    return iteratorValue;
+  }
+
+  public byte[] getData() {
+    return data;
+  }
+}

--- a/src/test/java/io/rebloom/client/CuckooTests.java
+++ b/src/test/java/io/rebloom/client/CuckooTests.java
@@ -1,0 +1,340 @@
+package io.rebloom.client;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import redis.clients.jedis.exceptions.JedisDataException;
+
+import io.rebloom.client.cf.IteratorDataPair;
+
+/**
+ * Tests for the Cuckoo Filter Implementation
+ *
+ */
+public class CuckooTests {
+  static final int port;
+  static {
+    String tmpPort = System.getenv("REBLOOM_TEST_PORT");
+    if (tmpPort != null && !tmpPort.isEmpty()) {
+      port = Integer.parseInt(tmpPort);
+    } else {
+      port = 6379;
+    }
+  }
+
+  Client cl = null;
+
+  @Before
+  public void clearDb() {
+    cl = new Client("localhost", port);
+    cl._conn().flushDB();
+  }
+
+  @Test
+  public void testReservationCapacityOnly() {
+    cl.cfCreate("cuckoo1", 10);
+    Map<String, Long> info = cl.cfInfo("cuckoo1");
+
+    assertEquals(8L, info.get("Number of buckets").longValue());
+    assertEquals(0L, info.get("Number of items inserted").longValue());
+    assertEquals(72L, info.get("Size").longValue());
+    assertEquals(1L, info.get("Expansion rate").longValue());
+    assertEquals(1L, info.get("Number of filters").longValue());
+    assertEquals(2L, info.get("Bucket size").longValue());
+    assertEquals(20L, info.get("Max iterations").longValue());
+    assertEquals(0L, info.get("Number of items deleted").longValue());
+  }
+
+  @Test
+  public void testReservationCapacityAndBucketSize() {
+    cl.cfCreate("cuckoo2", 200, 10);
+    Map<String, Long> info = cl.cfInfo("cuckoo2");
+
+    assertEquals(32L, info.get("Number of buckets").longValue());
+    assertEquals(0L, info.get("Number of items inserted").longValue());
+    assertEquals(376L, info.get("Size").longValue());
+    assertEquals(1L, info.get("Expansion rate").longValue());
+    assertEquals(1L, info.get("Number of filters").longValue());
+    assertEquals(10L, info.get("Bucket size").longValue());
+    assertEquals(20L, info.get("Max iterations").longValue());
+    assertEquals(0L, info.get("Number of items deleted").longValue());
+  }
+
+  @Test
+  public void testReservationCapacityAndBucketSizeAndMaxIterations() {
+    cl.cfCreate("cuckoo3", 200, 10, 20);
+    Map<String, Long> info = cl.cfInfo("cuckoo3");
+
+    assertEquals(32L, info.get("Number of buckets").longValue());
+    assertEquals(0L, info.get("Number of items inserted").longValue());
+    assertEquals(376L, info.get("Size").longValue());
+    assertEquals(1L, info.get("Expansion rate").longValue());
+    assertEquals(1L, info.get("Number of filters").longValue());
+    assertEquals(10L, info.get("Bucket size").longValue());
+    assertEquals(20L, info.get("Max iterations").longValue());
+    assertEquals(0L, info.get("Number of items deleted").longValue());
+  }
+
+  @Test
+  public void testReservationAllParams() {
+    cl.cfCreate("cuckoo4", 200, 10, 20, 4);
+    Map<String, Long> info = cl.cfInfo("cuckoo4");
+
+    assertEquals(32L, info.get("Number of buckets").longValue());
+    assertEquals(0L, info.get("Number of items inserted").longValue());
+    assertEquals(376L, info.get("Size").longValue());
+    assertEquals(4L, info.get("Expansion rate").longValue());
+    assertEquals(1L, info.get("Number of filters").longValue());
+    assertEquals(10L, info.get("Bucket size").longValue());
+    assertEquals(20L, info.get("Max iterations").longValue());
+    assertEquals(0L, info.get("Number of items deleted").longValue());
+  }
+
+  @Test
+  public void testAdd() {
+    cl.cfCreate("cuckoo5", 64000);
+    assertTrue(cl.cfAdd("cuckoo5", "test"));
+
+    Map<String, Long> info = cl.cfInfo("cuckoo5");
+    assertEquals(1L, info.get("Number of items inserted").longValue());
+  }
+
+  @Test
+  public void testAddNxItemDoesExist() {
+    cl.cfCreate("cuckoo6", 64000);
+    assertTrue(cl.cfAddNx("cuckoo6", "filter"));
+  }
+
+  @Test
+  public void testAddNxItemExists() {
+    cl.cfCreate("cuckoo7", 64000);
+    cl.cfAdd("cuckoo7", "filter");
+    assertFalse(cl.cfAddNx("cuckoo7", "filter"));
+  }
+
+  @Test
+  public void testInsert() {
+    assertArrayEquals( //
+        new Boolean[] { true }, //
+        cl.cfInsert("cuckoo8", "foo").toArray(new Boolean[0]) //
+    );
+  }
+
+  @Test
+  public void testInsertWithCapacity() {
+    assertArrayEquals( //
+        new Boolean[] { true }, //
+        cl.cfInsert("cuckoo9", 1000, "foo").toArray(new Boolean[0]) //
+    );
+  }
+
+  @Test
+  public void testInsertNoCreateFilterDoesNotExist() {
+    Exception ex = assertThrows(JedisDataException.class, () -> {
+      cl.cfInsertNoCreate("cuckoo10", "foo", "bar");
+    });
+    assertTrue(ex.getMessage().contains("ERR not found"));
+  }
+
+  @Test
+  public void testInsertNoCreateFilterExists() {
+    cl.cfInsert("cuckoo11", "bar");
+    assertArrayEquals( //
+        new Boolean[] { true, true }, //
+        cl.cfInsertNoCreate("cuckoo11", "foo", "bar").toArray(new Boolean[0]) //
+    );
+  }
+
+  @Test
+  public void testInsertNx() {
+    assertArrayEquals( //
+        new Boolean[] { true }, //
+        cl.cfInsertNx("cuckoo12", "bar").toArray(new Boolean[0]) //
+    );
+  }
+
+  @Test
+  public void testInsertNxWithCapacity() {
+    cl.cfInsertNx("cuckoo13", "bar");
+    assertArrayEquals( //
+        new Boolean[] { false }, //
+        cl.cfInsertNx("cuckoo13", 1000, "bar").toArray(new Boolean[0]) //
+    );
+  }
+
+  @Test
+  public void testInsertNxMultiple() {
+    cl.cfInsertNx("cuckoo14", "foo");
+    cl.cfInsertNx("cuckoo14", "bar");
+    assertArrayEquals(//
+        new Boolean[] { false, false, true }, //
+        cl.cfInsertNx("cuckoo14", "foo", "bar", "baz").toArray(new Boolean[0])//
+    );
+  }
+
+  @Test
+  public void testInsertNxNoCreate() {
+    Exception ex = assertThrows(JedisDataException.class, () -> {
+      cl.cfInsertNxNoCreate("cuckoo15", "foo", "bar");
+    });
+    assertTrue(ex.getMessage().contains("ERR not found"));
+  }
+
+  @Test
+  public void testExistsItemDoesntExist() {
+    assertFalse(cl.cfExists("cuckoo16", "foo"));
+  }
+
+  @Test
+  public void testExistsItemExists() {
+    cl.cfInsert("cuckoo17", "foo");
+    assertTrue(cl.cfExists("cuckoo17", "foo"));
+  }
+
+  @Test
+  public void testDeleteItemDoesntExist() {
+    cl.cfInsert("cuckoo8", "bar");
+    assertFalse(cl.cfDel("cuckoo8", "foo"));
+  }
+
+  @Test
+  public void testDeleteItemExists() {
+    cl.cfInsert("cuckoo18", "foo");
+    assertTrue(cl.cfDel("cuckoo18", "foo"));
+  }
+
+  @Test
+  public void testDeleteFilterDoesNotExist() {
+    Exception ex = assertThrows(JedisDataException.class, () -> {
+      cl.cfDel("cuckoo19", "foo");
+    });
+    assertTrue(ex.getMessage().contains("Not found"));
+  }
+
+  @Test
+  public void testCountFilterDoesNotExist() {
+    assertEquals(0L, cl.cfCount("cuckoo20", "filter"));
+  }
+
+  @Test
+  public void testCountFilterExist() {
+    cl.cfInsert("cuckoo21", "foo");
+    assertEquals(0L, cl.cfCount("cuckoo21", "filter"));
+  }
+
+  @Test
+  public void testCountItemExists() {
+    cl.cfInsert("cuckoo22", "foo");
+    assertEquals(1L, cl.cfCount("cuckoo22", "foo"));
+  }
+
+  @Test
+  public void testInfoFilterDoesNotExists() {
+    Exception ex = assertThrows(JedisDataException.class, () -> {
+      cl.cfInfo("cuckoo23");
+    });
+    assertTrue(ex.getMessage().contains("ERR not found"));
+  }
+
+  @Test
+  public void testScanDump() {
+    cl.cfCreate("cuckoo24", 100, 50);
+    cl.cfAdd("cuckoo24", "a");
+
+    long iter = 0;
+    List<IteratorDataPair> chunks = new ArrayList<>();
+    while (true) {
+      IteratorDataPair chunksData = cl.cfScanDump("cuckoo24", iter);
+      iter = chunksData.getIteratorValue();
+      if (iter == 0) {
+        break;
+      }
+      chunks.add(chunksData);
+    }
+
+    cl.delete("cuckoo24");
+
+    // Load it back
+    chunks.forEach(chunksData -> cl.cfLoadChunk("cuckoo24", chunksData));
+
+    // check the bucket size
+    Map<String, Long> info = cl.cfInfo("cuckoo24");
+
+    // check the retrieved filter properties
+    assertEquals(1L, info.get("Number of items inserted").longValue());
+    assertEquals(50L, info.get("Bucket size").longValue());
+    assertEquals(0L, info.get("Number of items deleted").longValue());
+
+    // check for existing items
+    assertTrue(cl.cfExists("cuckoo24", "a"));
+  }
+  
+  @Test
+  public void testScanDumpWithIterator() {
+    cl.cfCreate("cuckoo25", 100, 50);
+    cl.cfAdd("cuckoo25", "b");
+    
+    List<IteratorDataPair> chunks = new ArrayList<>();
+    Iterator<IteratorDataPair> i = cl.cfScanDumpIterator("cuckoo25");
+    while (i.hasNext()) {
+      chunks.add(i.next());
+    }
+
+    cl.delete("cuckoo25");
+
+    // Load it back
+    chunks.forEach(chunksData -> {
+      cl.cfLoadChunk("cuckoo25", chunksData);
+    });
+
+    // check the bucket size
+    Map<String, Long> info = cl.cfInfo("cuckoo25");
+
+    // check the retrieved filter properties
+    assertEquals(1L, info.get("Number of items inserted").longValue());
+    assertEquals(50L, info.get("Bucket size").longValue());
+    assertEquals(0L, info.get("Number of items deleted").longValue());
+
+    // check for existing items
+    assertTrue(cl.cfExists("cuckoo25", "b"));
+  }
+  
+  @Test
+  public void testScanDumpWithStream() {
+    cl.cfCreate("cuckoo26", 100, 50);
+    cl.cfAdd("cuckoo26", "c");
+    
+    List<IteratorDataPair> chunks = cl.cfScanDumpStream("cuckoo26").collect(Collectors.toList());
+    
+    cl.delete("cuckoo26");
+
+    // Load it back
+    chunks.forEach(chunksData -> {
+      cl.cfLoadChunk("cuckoo26", chunksData);
+    });
+
+    // check the bucket size
+    Map<String, Long> info = cl.cfInfo("cuckoo26");
+
+    // check the retrieved filter properties
+    assertEquals(1L, info.get("Number of items inserted").longValue());
+    assertEquals(50L, info.get("Bucket size").longValue());
+    assertEquals(0L, info.get("Number of items deleted").longValue());
+
+    // check for existing items
+    assertTrue(cl.cfExists("cuckoo26", "c"));
+  }
+
+}


### PR DESCRIPTION
- Adds `Cuckoo.java` interface in the `io.rebloom.client.cf` package that implements Cuckoo Filter commands
- Adds an implementation of the `Cuckoo` interface commands methods to `Client.java`
- Adds tests matching those in https://github.com/RedisBloom/redisbloom-py and more (`CF.SCANDUMP`/`CF.LOADCHUNK`)
- See https://github.com/RedisBloom/JRedisBloom/issues/26