### PR TITLE
Edit default port in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Initializing the client:
 ```java
 import io.rebloom.client.Client
 
-Client client = new Client("localhost", 6378);
+Client client = new Client("localhost", 6379);
 ```
 
 Adding items to a bloom filter (created using default settings):


### PR DESCRIPTION
https://github.com/RedisBloom/RedisBloom/blob/master/README.md uses `6379` as example port. It should be used here as well.