### PR TITLE
feat: allow client instantiation with a Jedis instance

### DIFF
--- a/src/main/java/io/rebloom/client/Client.java
+++ b/src/main/java/io/rebloom/client/Client.java
@@ -37,7 +37,7 @@ import redis.clients.jedis.util.SafeEncoder;
 public class Client implements Cuckoo, CMS, TDigest, Closeable {
 
   private final Pool<Jedis> pool;
-  private Jedis jedis;
+  private final Jedis jedis;
 
   /**
    * Create a new client to ReBloom
@@ -45,6 +45,7 @@ public class Client implements Cuckoo, CMS, TDigest, Closeable {
    */
   public Client(Pool<Jedis> pool){
     this.pool = pool;
+    this.jedis = null;
   }
 
   public Client(Jedis jedis) {
@@ -72,6 +73,7 @@ public class Client implements Cuckoo, CMS, TDigest, Closeable {
     conf.setFairness(true);
 
     pool = new JedisPool(conf, host, port, timeout);
+    jedis = null;
   }
 
   /**

--- a/src/main/java/io/rebloom/client/Client.java
+++ b/src/main/java/io/rebloom/client/Client.java
@@ -37,6 +37,7 @@ import redis.clients.jedis.util.SafeEncoder;
 public class Client implements Cuckoo, CMS, TDigest, Closeable {
 
   private final Pool<Jedis> pool;
+  private Jedis jedis;
 
   /**
    * Create a new client to ReBloom
@@ -46,6 +47,10 @@ public class Client implements Cuckoo, CMS, TDigest, Closeable {
     this.pool = pool;
   }
 
+  public Client(Jedis jedis) {
+    this.jedis = jedis;
+    this.pool = null;
+  }
 
   /**
    * Create a new client to ReBloom
@@ -80,11 +85,16 @@ public class Client implements Cuckoo, CMS, TDigest, Closeable {
 
   @Override
   public void close(){
-    this.pool.close();
+    if (pool != null) {
+      pool.close();
+    }
+    if (jedis != null) {
+      jedis.close();
+    }
   }
 
   Jedis _conn() {
-    return pool.getResource();
+    return jedis != null ? jedis : pool.getResource();
   }
 
   /**
@@ -395,7 +405,7 @@ public class Client implements Cuckoo, CMS, TDigest, Closeable {
          .getMultiBulkReply();
    }
  }
- 
+
  //
  // Count-Min-Sketch Implementation
  //

--- a/src/test/java/io/rebloom/client/ClientTest.java
+++ b/src/test/java/io/rebloom/client/ClientTest.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Map;
 import org.junit.Test;
 
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.exceptions.JedisException;
@@ -14,7 +15,7 @@ import redis.clients.jedis.exceptions.JedisException;
  * @author Mark Nunberg
  */
 public class ClientTest extends TestBase {
-    
+
     @Test
     public void createWithPool() {
       Client refClient;
@@ -24,6 +25,18 @@ public class ClientTest extends TestBase {
         assertTrue(client.delete("createBloom"));
       }
       assertThrows(JedisException.class, () -> refClient.createFilter("myBloom", 100, 0.001));
+    }
+
+    @Test
+    public void createWithJedisInstance() {
+      Client refClient;
+      Jedis jedis = new Jedis();
+      try(Client client = new Client(jedis)){
+        client.createFilter("createBloom", 100, 0.001);
+        assertTrue(client.delete("createBloom"));
+      } catch (Exception e) {
+        fail();
+      }
     }
 
     @Test


### PR DESCRIPTION
This PR allows JRedisBloom client to be instantiated used a Jedis instance (for envs that manage and serve their own connections, a.k.a. Spring)